### PR TITLE
Remove RDKit strict dependence

### DIFF
--- a/pyrosetta_help/ligands/load.py
+++ b/pyrosetta_help/ligands/load.py
@@ -1,6 +1,12 @@
 import pyrosetta, warnings, requests
 from ..common_ops.utils import make_blank_pose
-from rdkit_to_params import Params, neutralise
+try:
+    from rdkit_to_params import Params, neutralise
+except ImportError:
+    from warnings import warn
+    warn("rdkit_to_params couldn't be imported."
+         " LiganNicker and parameterised_pose_from_file won't work.")
+    pass
 from typing import *
 
 __all__ = ['parameterised_pose_from_file', 'parameterised_pose_from_pdbblock', 'get_smiles']

--- a/pyrosetta_help/ligands/nick.py
+++ b/pyrosetta_help/ligands/nick.py
@@ -4,6 +4,8 @@ try:
     from rdkit_to_params import Params, neutralise
 except ModuleNotFoundError:
     pass
+except ImportError:
+    pass
 from typing import *
 from ..common_ops.downloads import download_pdb
 from ..common_ops.utils import make_blank_pose


### PR DESCRIPTION
pyrosetta-help couldn't be imported if rdkit-to-params didn't provide neutralise. neutralise requires RDKit, which is optional in rdkit-to-params.
Now we can use pyrosetta-help without RDKit, albeit without the pyrosetta-help.ligands part.
The solution is somewhat unelegant, the other way around would be to specify that RDKit is a requirement in the README.